### PR TITLE
[Demo v2] Phase A unsuppressed unversioned change

### DIFF
--- a/specification/contosowidgetmanager/Contoso.Management/employee.tsp
+++ b/specification/contosowidgetmanager/Contoso.Management/employee.tsp
@@ -20,9 +20,6 @@ model EmployeeProperties {
   /** Age of employee */
   age?: int32;
 
-  /** City of employee */
-  city?: string;
-
   /** Profile of employee */
   @encode("base64url")
   profile?: bytes;

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2021-10-01-preview/contoso.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2021-10-01-preview/contoso.json
@@ -466,10 +466,6 @@
           "format": "int32",
           "description": "Age of employee"
         },
-        "city": {
-          "type": "string",
-          "description": "City of employee"
-        },
         "profile": {
           "type": "string",
           "format": "base64url",

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/contoso.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/contoso.json
@@ -466,10 +466,6 @@
           "format": "int32",
           "description": "Age of employee"
         },
-        "city": {
-          "type": "string",
-          "description": "City of employee"
-        },
         "profile": {
           "type": "string",
           "format": "base64url",


### PR DESCRIPTION
This demo mirrors the Phase A unsuppressed scenario on a fresh `demo/v2-base` branch.

Scenario:
- Modifies the existing spec without adding a new API version
- Removes `EmployeeProperties.city`
- No suppression decorator

Expected result: 1 unsuppressed Phase A `ResourcePropertyRemoved` finding.