### PR TITLE
[Demo v2] Phase A suppressed unversioned change

### DIFF
--- a/specification/contosowidgetmanager/Contoso.Management/employee.tsp
+++ b/specification/contosowidgetmanager/Contoso.Management/employee.tsp
@@ -2,11 +2,13 @@ import "@typespec/rest";
 import "@typespec/http";
 import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
+import "@azure-tools/typespec-breaking-change";
 
 using TypeSpec.Rest;
 using TypeSpec.Http;
 using Azure.Core;
 using Azure.ResourceManager;
+using Azure.BreakingChange;
 
 namespace Microsoft.Contoso;
 
@@ -16,12 +18,13 @@ model Employee is TrackedResource<EmployeeProperties> {
 }
 
 /** Employee properties */
+@approvedUnversionedChange(
+  "City field removed intentionally for demo coverage",
+  #{ kind: "ResourcePropertyRemoved", path: "city" }
+)
 model EmployeeProperties {
   /** Age of employee */
   age?: int32;
-
-  /** City of employee */
-  city?: string;
 
   /** Profile of employee */
   @encode("base64url")

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2021-10-01-preview/contoso.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2021-10-01-preview/contoso.json
@@ -466,10 +466,6 @@
           "format": "int32",
           "description": "Age of employee"
         },
-        "city": {
-          "type": "string",
-          "description": "City of employee"
-        },
         "profile": {
           "type": "string",
           "format": "base64url",

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/contoso.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/contoso.json
@@ -466,10 +466,6 @@
           "format": "int32",
           "description": "Age of employee"
         },
-        "city": {
-          "type": "string",
-          "description": "City of employee"
-        },
         "profile": {
           "type": "string",
           "format": "base64url",


### PR DESCRIPTION
This demo mirrors the Phase A suppressed scenario on a fresh `demo/v2-base` branch.

Scenario:
- Modifies the existing spec without adding a new API version
- Removes `EmployeeProperties.city`
- Adds `@approvedUnversionedChange(..., #{ kind: "ResourcePropertyRemoved", path: "city" })`

Expected result: 1 suppressed Phase A `ResourcePropertyRemoved` finding.